### PR TITLE
Add 'on-request' Hook to Ring Middlewares

### DIFF
--- a/src/iapetos/collector/ring.clj
+++ b/src/iapetos/collector/ring.clj
@@ -145,8 +145,8 @@
   "Expose Prometheus metrics at the given constant URI using the text format.
 
    If `:on-request` is given, it will be called with the collector registry
-   whenever a request comes in. This lets you use the Prometheus scraper as
-   a trigger for metrics collection."
+   whenever a request comes in (the result will be ignored). This lets you use
+   the Prometheus scraper as a trigger for metrics collection."
   [handler registry
    & [{:keys [path on-request]
        :or {path "/metrics"}}]]

--- a/src/iapetos/collector/ring.clj
+++ b/src/iapetos/collector/ring.clj
@@ -149,13 +149,13 @@
    the Prometheus scraper as a trigger for metrics collection."
   [handler registry
    & [{:keys [path on-request]
-       :or {path "/metrics"}}]]
+       :or {path       "/metrics"
+            on-request identity}}]]
   (fn [{:keys [request-method uri] :as request}]
     (if (= uri path)
       (if (= request-method :get)
         (do
-          (if on-request
-            (on-request registry))
+          (on-request registry)
           (metrics-response registry))
         {:status 405})
       (handler request))))


### PR DESCRIPTION
This lets us use the Prometheus scraper as a "tick" for metric collection, i.e.:

```clojure
(-> ...
    (wrap-metrics
      registry
      {:on-request (fn [registry]
                     (prometheus/set
                       (registry :some/gauge-value)
                       (count-something! db)))}))
```