### PR TITLE
Add extra-labels to Ring collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea
+*.iml


### PR DESCRIPTION
Currently the default labels are [:method :status :statusClass :path].

I would like to have the ability to add extra labels from the request or response.

If this is not the right approach, do you have any other ideas for how to solve it?

Thank you.