### PR TITLE
Code Coverage Report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+after_success:
+- lein codecov
+- bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
-# iapetos [![Build Status](https://travis-ci.org/xsc/iapetos.svg?branch=master)](https://travis-ci.org/xsc/iapetos)
+# iapetos
 
 __iapetos__ is a Clojure wrapper around the [Prometheus Java
 Client][java-client], providing idiomatic and simple access to commonly used
 functionality while retaining low-level flexibility for tackling more complex
 tasks.
 
-[java-client]: https://github.com/prometheus/client_java
-
-## Usage
-
-__Leiningen__ ([via Clojars](https://clojars.org/iapetos))
-
+[![Build Status](https://travis-ci.org/xsc/iapetos.svg?branch=master)](https://travis-ci.org/xsc/iapetos)
 [![Clojars Project](https://img.shields.io/clojars/v/iapetos.svg)](https://clojars.org/iapetos)
+[![codecov](https://codecov.io/gh/xsc/iapetos/branch/master/graph/badge.svg)](https://codecov.io/gh/xsc/iapetos)
+
+[java-client]: https://github.com/prometheus/client_java
 
 ## Basic Usage
 

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,11 @@
                       :namespaces [iapetos.core
                                    iapetos.export
                                    iapetos.standalone
-                                   #"^iapetos\.collector\..+"]}}}
-  :aliases {"codox" ["with-profile" "+codox" "codox"]}
+                                   #"^iapetos\.collector\..+"]}}
+             :coverage
+             {:plugins [[lein-cloverage "1.0.9"]]
+              :dependencies [[org.clojure/tools.reader "1.1.0"]
+                             [riddley "0.1.14"]]}}
+  :aliases {"codox" ["with-profile" "+codox" "codox"]
+            "codecov" ["with-profile" "+coverage" "cloverage" "--codecov"]}
   :pedantic? :abort)


### PR DESCRIPTION
This adds code coverage reporting, both as a Leiningen alias, as well as via codecov.io.