### PR TITLE
Decouple collector instantiation from registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ All metrics have to be registered with a collector registry before being used:
   (-> (prometheus/collector-registry)
       (prometheus/register
         (prometheus/histogram :app/duration-seconds)
-        (prometheus/gauge     :app/last-success-unixtime {:lazy? true})
-        (prometheus/gauge     :app/active-users-total    {:lazy? true})
-        (prometheus/counter   :app/runs-total))))
+        (prometheus/gauge     :app/active-users-total)
+        (prometheus/counter   :app/runs-total))
+      (prometheus/register-lazy
+        (prometheus/gauge     :app/last-success-unixtime))))
 ```
 
 Now, they are ready to be set and changed:

--- a/src/iapetos/collector.clj
+++ b/src/iapetos/collector.clj
@@ -112,10 +112,9 @@
   (metric [this]
     (raw-metric this))
   (label-instance [_ instance values]
-    ;; not possible to read required labels from SimpleCollector :|
-    #_(let [labels (.-labelNames ^SimpleCollector instance)]
-        (set-labels instance labels values))
-    instance)
+    (if-not (empty? values)
+      (throw (UnsupportedOperationException.))
+      instance))
 
   io.prometheus.client.Collector
   (instantiate [this _]
@@ -134,8 +133,10 @@
       instance)
     (metric [_]
       metric)
-    (label-instance [_ _ _]
-      (throw (UnsupportedOperationException.)))))
+    (label-instance [_ instance values]
+      (when-not (empty? values)
+        (throw (UnsupportedOperationException.)))
+      instance)))
 
 ;; ## Collector Bundle
 
@@ -147,5 +148,7 @@
         instances)
       (metric [_]
         metric)
-      (label-instance [_ _ _]
-        (throw (UnsupportedOperationException.))))))
+      (label-instance [_ instance values]
+        (if-not (empty? values)
+          (throw (UnsupportedOperationException.))
+          instance)))))

--- a/src/iapetos/collector/exceptions.clj
+++ b/src/iapetos/collector/exceptions.clj
@@ -39,8 +39,8 @@
 
 (deftype ExceptionCounter [counter]
   collector/Collector
-  (instantiate [this registry registry-options]
-    (collector/instantiate counter registry registry-options))
+  (instantiate [this registry-options]
+    (collector/instantiate counter registry-options))
   (metric [this]
     (collector/metric counter))
   (label-instance [_ instance values]

--- a/src/iapetos/export.clj
+++ b/src/iapetos/export.clj
@@ -41,6 +41,12 @@
       job
       push-gateway
       grouping-key))
+  (register-lazy [_ metric collector]
+    (PushableRegistry.
+      (registry/register-lazy internal-registry metric collector)
+      job
+      push-gateway
+      grouping-key))
   (subsystem [_ subsystem-name]
     (PushableRegistry.
       (registry/subsystem internal-registry subsystem-name)

--- a/src/iapetos/registry.clj
+++ b/src/iapetos/registry.clj
@@ -14,6 +14,9 @@
   (register [registry metric collector]
     "Add the given `iapetos.collector/Collector` to the registry using the
      given name.")
+  (register-lazy [registry metric collector]
+    "Add the given `iapetos.collector/Collector` to the registry using the
+     given name, but only actually register it on first use.")
   (get [registry metric labels]
     "Retrieve the collector instance associated with the given metric,
      setting the given labels.")
@@ -28,7 +31,11 @@
   Registry
   (register [this metric collector]
     (->> (collectors/prepare registry metric collector options)
-         (collectors/register-if-not-lazy)
+         (collectors/register)
+         (collectors/insert collectors)
+         (IapetosRegistry. registry-name registry options)))
+  (register-lazy [this metric collector]
+    (->> (collectors/prepare registry metric collector options)
          (collectors/insert collectors)
          (IapetosRegistry. registry-name registry options)))
   (subsystem [_ subsystem-name]

--- a/src/iapetos/registry/collectors.clj
+++ b/src/iapetos/registry/collectors.clj
@@ -1,0 +1,50 @@
+(ns iapetos.registry.collectors
+  (:require [iapetos.registry.utils :as utils]
+            [iapetos.collector :as collector])
+  (:import [io.prometheus.client Collector CollectorRegistry]))
+
+;; ## Init
+
+(defn initialize
+  []
+  {})
+
+;; ## Management
+
+(defn- register-collector-delay
+  [^CollectorRegistry registry ^Collector instance]
+  (delay
+    (.register registry instance)
+    instance))
+
+(defn prepare
+  [registry metric collector options]
+  (let [path (utils/metric->path metric options)
+        instance (collector/instantiate collector options)]
+    {:collector collector
+     :metric    metric
+     :path      path
+     :raw       instance
+     :instance  (register-collector-delay registry instance)}))
+
+(defn insert
+  [collectors {:keys [path] :as collector}]
+  (assoc-in collectors path collector))
+
+(defn register-if-not-lazy
+  [{:keys [collector instance] :as collector-map}]
+  (when-not (:lazy? collector)
+    @instance)
+  collector-map)
+
+;; ## Read Access
+
+(defn- label-collector
+  [labels {:keys [collector instance]}]
+  (collector/label-instance collector @instance labels))
+
+(defn by
+  [collectors metric labels options]
+  (some->> (utils/metric->path metric options)
+           (get-in collectors)
+           (label-collector labels)))

--- a/src/iapetos/registry/collectors.clj
+++ b/src/iapetos/registry/collectors.clj
@@ -17,24 +17,34 @@
     (.register registry instance)
     instance))
 
+(defn- warn-lazy-deprecation!
+  [{:keys [collector instance] :as collector-map}]
+  (let [lazy? (:lazy? collector)]
+    (when (some? lazy?)
+      (println "collector option ':lazy?' is deprecated, use 'register-lazy' instead.")
+      (println "collector: " (pr-str collector))
+      (when-not lazy?
+        @instance)))
+  collector-map)
+
 (defn prepare
   [registry metric collector options]
   (let [path (utils/metric->path metric options)
         instance (collector/instantiate collector options)]
-    {:collector collector
-     :metric    metric
-     :path      path
-     :raw       instance
-     :instance  (register-collector-delay registry instance)}))
+    (-> {:collector collector
+         :metric    metric
+         :path      path
+         :raw       instance
+         :instance  (register-collector-delay registry instance)}
+        (warn-lazy-deprecation!))))
 
 (defn insert
   [collectors {:keys [path] :as collector}]
   (assoc-in collectors path collector))
 
-(defn register-if-not-lazy
+(defn register
   [{:keys [collector instance] :as collector-map}]
-  (when-not (:lazy? collector)
-    @instance)
+  @instance
   collector-map)
 
 ;; ## Read Access

--- a/src/iapetos/registry/utils.clj
+++ b/src/iapetos/registry/utils.clj
@@ -1,0 +1,13 @@
+(ns iapetos.registry.utils
+  (:require [iapetos.metric :as metric]))
+
+(defn join-subsystem
+  [old-subsystem subsystem]
+  (if (seq old-subsystem)
+    (metric/sanitize (str old-subsystem "_" subsystem))
+    subsystem))
+
+(defn metric->path
+  [metric {:keys [subsystem]}]
+  (let [{:keys [name namespace]} (metric/metric-name metric)]
+    [namespace subsystem name]))

--- a/test/iapetos/collector/jvm_test.clj
+++ b/test/iapetos/collector/jvm_test.clj
@@ -1,0 +1,19 @@
+(ns iapetos.collector.jvm-test
+  (:require [clojure.test.check
+             [generators :as gen]
+             [properties :as prop]
+             [clojure-test :refer [defspec]]]
+            [clojure.test :refer :all]
+            [iapetos.test.generators :as g]
+            [iapetos.core :as prometheus]
+            [iapetos.collector.jvm :as jvm]))
+
+(defspec t-jvm-collectors 10
+  (prop/for-all
+    [registry-fn (g/registry-fn)]
+    (let [registry (-> (registry-fn)
+                       (jvm/initialize))]
+      (and (registry :iapetos-internal/jvm-standard)
+           (registry :iapetos-internal/jvm-gc)
+           (registry :iapetos-internal/jvm-memory-pools)
+           (registry :iapetos-internal/jvm-threads)))))

--- a/test/iapetos/collector_test.clj
+++ b/test/iapetos/collector_test.clj
@@ -1,0 +1,45 @@
+(ns iapetos.collector-test
+  (:require [clojure.test.check
+             [generators :as gen]
+             [properties :as prop]
+             [clojure-test :refer [defspec]]]
+            [clojure.test :refer :all]
+            [iapetos.test.generators :as g]
+            [iapetos.collector :as c])
+  (:import [io.prometheus.client
+            Counter
+            Histogram
+            Gauge
+            SimpleCollector$Builder
+            Summary]))
+
+(def gen-raw-collector
+  (gen/let [builder (gen/elements
+                      [(Counter/build)
+                       (Histogram/build)
+                       (Gauge/build)
+                       (Summary/build)])
+            collector-namespace g/metric-string
+            collector-name g/metric-string
+            help-string (gen/not-empty gen/string-ascii)]
+    (gen/return
+      {:collector           (-> ^SimpleCollector$Builder
+                                 builder
+                                 (.name collector-name)
+                                 (.namespace collector-namespace)
+                                 (.help help-string)
+                                 (.create))
+       :collector-namespace collector-namespace
+       :collector-name      collector-name})))
+
+(defspec t-raw-collectors 20
+  (prop/for-all
+    [{:keys [collector collector-name collector-namespace]}
+     gen-raw-collector]
+    (and (is (= collector
+                (c/instantiate collector {})))
+         (is (= {:name      collector-name
+                 :namespace collector-namespace}
+                (c/metric collector)))
+         (is (= collector
+                (c/label-instance collector collector {}))))))

--- a/test/iapetos/core/lazy_test.clj
+++ b/test/iapetos/core/lazy_test.clj
@@ -1,0 +1,40 @@
+(ns iapetos.core.lazy-test
+  (:require [clojure.test.check
+             [generators :as gen]
+             [properties :as prop]
+             [clojure-test :refer [defspec]]]
+            [clojure.test :refer :all]
+            [iapetos.test.generators :as g]
+            [iapetos.core :as prometheus]
+            [iapetos.export :as export]))
+
+(def gen-collector-constructor
+  (gen/elements
+    [prometheus/gauge
+     prometheus/counter
+     prometheus/summary]))
+
+(defspec t-lazy-deprecation 20
+  (prop/for-all
+    [registry-fn    (g/registry-fn)
+     collector-fn   g/collector-constructor
+     collector-name g/metric]
+    (let [collector (collector-fn collector-name {:lazy? true})
+          registry  (registry-fn)
+          output    (with-out-str
+                      (prometheus/register registry collector))]
+      (.startsWith
+        ^String output
+        "collector option ':lazy?' is deprecated, use 'register-lazy' instead."))))
+
+(defspec t-register-lazy 100
+  (prop/for-all
+    [registry-fn    (g/registry-fn)
+     collector-fn   g/collector-constructor
+     collector-name g/metric]
+    (let [collector (collector-fn collector-name)
+          registry  (-> (registry-fn)
+                        (prometheus/register-lazy collector))]
+      (and (is (= "" (export/text-format registry)))
+           (is (registry collector-name))
+           (is (not= "" (export/text-format registry)))))))

--- a/test/iapetos/core/summary_test.clj
+++ b/test/iapetos/core/summary_test.clj
@@ -98,8 +98,8 @@
     [registry-fn (g/registry-fn)]
     (let [metric :app/duration-seconds
           registry (-> (registry-fn)
-                       (prometheus/register
-                         (prometheus/summary metric {:lazy? true})))
+                       (prometheus/register-lazy
+                         (prometheus/summary metric)))
           start      (System/nanoTime)
           stop-timer (prometheus/start-timer registry metric)
           _          (do (Thread/sleep 50) (stop-timer))

--- a/test/iapetos/test/generators.clj
+++ b/test/iapetos/test/generators.clj
@@ -16,7 +16,7 @@
 (def metric-string
   (gen/let [first-char gen/char-alpha
             last-char  gen/char-alpha-numeric
-            rest-chars gen/string-ascii]
+            rest-chars gen/string-alpha-numeric]
     (gen/return
       (str
         (apply str first-char rest-chars)

--- a/test/iapetos/test/generators.clj
+++ b/test/iapetos/test/generators.clj
@@ -63,6 +63,7 @@
   (gen/let [registry-name valid-name
             base-fn (gen/elements
                       [#(prometheus/collector-registry %)
+                       #(do % (prometheus/collector-registry))
                        #(pushable-collector-registry
                           {:job %
                            :push-gateway "0:8080"})

--- a/test/iapetos/test/generators.clj
+++ b/test/iapetos/test/generators.clj
@@ -89,13 +89,16 @@
            registry (prometheus/register (registry-fn) collector)]
        (gen/return (registry metric))))))
 
+(def collector-constructor
+  (gen/elements
+    [prometheus/counter
+     prometheus/gauge
+     prometheus/histogram
+     prometheus/summary]))
+
 (def collectors
   (gen/vector
-    (gen/let [metric metric
-              metric-fn (gen/elements
-                          [prometheus/counter
-                           prometheus/gauge
-                           prometheus/histogram
-                           prometheus/summary])]
+    (gen/let [metric    metric
+              metric-fn collector-constructor]
       (gen/return
         (metric-fn metric)))))


### PR DESCRIPTION
This PR makes it possible to retrieve a raw `Collector` instance when calling `instantiate` on a iapetos collector. Subsequently this instance can be registered on any collector registry.

Additionally, `:lazy?` is now deprecated in favour of the new `register-lazy` since it shouldn't be a property of the collector how it is registered.