### PR TITLE
Unregister and Clear

### DIFF
--- a/src/iapetos/core.clj
+++ b/src/iapetos/core.clj
@@ -59,6 +59,16 @@
   [registry metric collector]
   (registry/register registry metric collector))
 
+(defn ^{:added "0.1.8"} unregister
+  "Unregister the given collectors."
+  [registry & collector-names]
+  (reduce registry/unregister registry collector-names))
+
+(defn ^{:added "0.1.8"} clear
+  "Unregister the given collectors."
+  [registry]
+  (registry/clear registry))
+
 (defn subsystem
   "Create a new registry bound to the given subsystem. The resulting value will
    not have access to any of the original registry's collectors.

--- a/src/iapetos/core.clj
+++ b/src/iapetos/core.clj
@@ -216,7 +216,7 @@
    was passed in."
   (fn
     ([collector]
-     (ops/increment collector 1.0)
+     (ops/increment collector)
      collector)
     ([a b]
      (?-> a
@@ -252,7 +252,7 @@
    was passed in."
   (fn
     ([collector]
-     (ops/decrement collector 1.0)
+     (ops/decrement collector)
      collector)
     ([a b]
      (?-> a

--- a/src/iapetos/registry/collectors.clj
+++ b/src/iapetos/registry/collectors.clj
@@ -17,6 +17,12 @@
     (.register registry instance)
     instance))
 
+(defn- unregister-collector-delay
+  [^CollectorRegistry registry ^Collector instance]
+  (delay
+    (.unregister registry instance)
+    instance))
+
 (defn- warn-lazy-deprecation!
   [{:keys [collector instance] :as collector-map}]
   (let [lazy? (:lazy? collector)]
@@ -31,30 +37,56 @@
   [registry metric collector options]
   (let [path (utils/metric->path metric options)
         instance (collector/instantiate collector options)]
-    (-> {:collector collector
-         :metric    metric
-         :path      path
-         :raw       instance
-         :instance  (register-collector-delay registry instance)}
+    (-> {:collector  collector
+         :metric     metric
+         :path       path
+         :raw        instance
+         :register   (register-collector-delay registry instance)
+         :unregister (unregister-collector-delay registry instance)}
         (warn-lazy-deprecation!))))
 
 (defn insert
   [collectors {:keys [path] :as collector}]
   (assoc-in collectors path collector))
 
+(defn delete
+  [collectors {:keys [path] :as collector}]
+  (update-in collectors
+             (butlast path)
+             dissoc
+             (last path)))
+
+(defn unregister
+  [collectors {:keys [register unregister] :as collector}]
+  (when (realized? register)
+    @unregister)
+  (delete collectors collector))
+
 (defn register
-  [{:keys [collector instance] :as collector-map}]
-  @instance
-  collector-map)
+  [collectors {:keys [register] :as collector}]
+  @register
+  (insert collectors collector))
+
+(defn clear
+  [collectors]
+  (->> (for [[namespace vs] collectors
+             [subsystem vs] vs
+             [_ collector] vs]
+         collector)
+       (reduce unregister collectors)))
 
 ;; ## Read Access
 
 (defn- label-collector
-  [labels {:keys [collector instance]}]
-  (collector/label-instance collector @instance labels))
+  [labels {:keys [collector register]}]
+  (collector/label-instance collector @register labels))
+
+(defn lookup
+  [collectors metric options]
+  (some->> (utils/metric->path metric options)
+           (get-in collectors)))
 
 (defn by
   [collectors metric labels options]
-  (some->> (utils/metric->path metric options)
-           (get-in collectors)
+  (some->> (lookup collectors metric options)
            (label-collector labels)))

--- a/test/iapetos/collector_test.clj
+++ b/test/iapetos/collector_test.clj
@@ -41,5 +41,8 @@
          (is (= {:name      collector-name
                  :namespace collector-namespace}
                 (c/metric collector)))
+         (is (thrown?
+               UnsupportedOperationException
+               (c/label-instance collector collector {:label "value"})))
          (is (= collector
-                (c/label-instance collector collector {}))))))
+                (c/label-instance collector collector {}))) )))

--- a/test/iapetos/registry_test.clj
+++ b/test/iapetos/registry_test.clj
@@ -1,0 +1,76 @@
+(ns iapetos.registry-test
+  (:require [clojure.test.check
+             [generators :as gen]
+             [properties :as prop]
+             [clojure-test :refer [defspec]]]
+            [clojure.test :refer :all]
+            [iapetos.test.generators :as g]
+            [iapetos.core :as prometheus]
+            [iapetos.collector :as c]
+            [iapetos.export :as export]))
+
+(defspec t-registry-should-return-nil-for-unknown-collectors 50
+  (prop/for-all
+    [registry-fn           (g/registry-fn)
+     collector-name        g/metric]
+    (let [registry (registry-fn)]
+      (nil? (registry collector-name)))))
+
+(defspec t-registry-should-return-a-registered-collector 50
+  (prop/for-all
+    [registry-fn           (g/registry-fn)
+     collector-constructor g/collector-constructor
+     collector-name        g/metric]
+    (let [collector (collector-constructor collector-name)
+          registry (-> (registry-fn)
+                       (prometheus/register collector))]
+      (some? (registry collector-name)))))
+
+(defspec t-registry-should-return-a-registered-collector-with-explicit-name 50
+  (prop/for-all
+    [registry-fn           (g/registry-fn)
+     collector-constructor g/collector-constructor
+     collector-name        g/metric
+     register-name         g/metric]
+    (let [collector (collector-constructor collector-name)
+          registry (-> (registry-fn)
+                       (prometheus/register-as register-name collector))]
+      (some? (registry register-name)))))
+
+(defspec t-registry-should-return-nil-for-unregistered-collectors 50
+  (prop/for-all
+    [registry-fn           (g/registry-fn)
+     collector-constructor g/collector-constructor
+     collector-name        g/metric]
+    (let [collector (collector-constructor collector-name)
+          registry (-> (registry-fn)
+                       (prometheus/register collector)
+                       (prometheus/unregister collector-name))]
+      (nil? (registry collector-name)))))
+
+(defspec t-registry-should-clear-all-collectors 50
+  (prop/for-all
+    [registry-fn           (g/registry-fn)
+     collectors            (gen/not-empty g/collectors)]
+    (let [registry (apply prometheus/register (registry-fn) collectors)]
+      (and (is (not= "" (export/text-format registry)))
+           (let [cleared-registry (prometheus/clear registry)]
+             (is (= "" (export/text-format cleared-registry))))))))
+
+(defspec t-subsystem=registry-should-only-clear-own-collectors 50
+  (prop/for-all
+    [registry-fn   (g/registry-fn)
+     collectors    g/collectors]
+    (let [[h & rst] collectors
+          registry (-> (registry-fn)
+                       (cond-> h (prometheus/register h)))
+          export-before (export/text-format registry)
+          subregistry (apply prometheus/register
+                             (prometheus/subsystem registry "sub")
+                             (rest collectors))
+          export-with-sub (export/text-format registry)
+          subregistry' (prometheus/clear subregistry)
+          export-after (export/text-format registry)]
+      (and (= export-before export-after)
+           (or (not (seq rst))
+               (not= export-with-sub export-before))))))

--- a/test/iapetos/test/generators.clj
+++ b/test/iapetos/test/generators.clj
@@ -98,8 +98,8 @@
      prometheus/summary]))
 
 (def collectors
-  (gen/vector
-    (gen/let [metric    metric
-              metric-fn collector-constructor]
-      (gen/return
-        (metric-fn metric)))))
+  (gen/let [metrics (gen/vector-distinct metric)]
+    (->> (gen/vector collector-constructor (count metrics))
+         (gen/fmap
+           (fn [fs]
+             (mapv #(%1 %2) fs metrics))))))

--- a/test/iapetos/test/generators.clj
+++ b/test/iapetos/test/generators.clj
@@ -68,10 +68,10 @@
                           {:job %
                            :push-gateway "0:8080"})
                        (constantly prometheus/default-registry)])]
-    (let [registry (base-fn registry-name)]
-      (.clear ^CollectorRegistry (iapetos.registry/raw registry))
-      (gen/return
-        (fn []
+    (gen/return
+      (fn []
+        (let [registry (base-fn registry-name)]
+          (.clear ^CollectorRegistry (iapetos.registry/raw registry))
           (reduce
             (fn [r f]
               (f r))


### PR DESCRIPTION
This adds `unregister` and `clear` functions for registries, allowing removal only of collectors previousl registered on them. This means that `clear` will not call `.clear()` on the underlying registry but just remove all collectors registered via iapetos.