### PR TITLE
Add more JVM collectors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,10 +6,10 @@
             :year 2016
             :key "mit"}
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
-                 [io.prometheus/simpleclient "0.2.0"]
-                 [io.prometheus/simpleclient_common "0.2.0"]
-                 [io.prometheus/simpleclient_pushgateway "0.2.0"]
-                 [io.prometheus/simpleclient_hotspot "0.2.0" :scope "provided"]]
+                 [io.prometheus/simpleclient "0.4.0"]
+                 [io.prometheus/simpleclient_common "0.4.0"]
+                 [io.prometheus/simpleclient_pushgateway "0.4.0"]
+                 [io.prometheus/simpleclient_hotspot "0.4.0" :scope "provided"]]
   :profiles {:dev
              {:dependencies [[org.clojure/test.check "0.9.0"]
                              [aleph "0.4.4"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject iapetos "0.1.9-SNAPSHOT"
+(defproject iapetos "0.1.9"
   :description "A Clojure Prometheus Client"
   :url "https://github.com/xsc/iapetos"
   :license {:name "MIT License"

--- a/src/iapetos/collector/jvm.clj
+++ b/src/iapetos/collector/jvm.clj
@@ -5,6 +5,9 @@
             Collector
             CollectorRegistry]
            [io.prometheus.client.hotspot
+            BufferPoolsExports
+            ClassLoadingExports
+            VersionInfoExports
             StandardExports
             MemoryPoolsExports
             GarbageCollectorExports
@@ -48,6 +51,33 @@
      :name      "jvm_threads"}
     (ThreadExports.)))
 
+(defn buffer-pools
+  "Exports metrics about JVM buffers.
+   Can be attached to a iapetos registry using `iapetos.core/register`."
+  []
+  (collector/named
+    {:namespace "iapetos_internal"
+     :name      "jvm_buffer_pools"}
+    (BufferPoolsExports.)))
+
+(defn class-loading
+  "Exports metrics about JVM classloading.
+   Can be attached to a iapetos registry using `iapetos.core/register`."
+  []
+  (collector/named
+    {:namespace "iapetos_internal"
+     :name      "jvm_class_loading"}
+    (ClassLoadingExports.)))
+
+ (defn version-info
+  "Exports JVM version info.
+   Can be attached to a iapetos registry using `iapetos.core/register`."
+  []
+  (collector/named
+    {:namespace "iapetos_internal"
+     :name      "jvm_version_info"}
+    (VersionInfoExports.)))
+
 ;; ## Initialize
 
 (defn initialize
@@ -58,4 +88,7 @@
         (standard)
         (gc)
         (memory-pools)
-        (threads))))
+        (threads)
+        (buffer-pools)
+        (class-loading)
+        (version-info))))

--- a/test/iapetos/collector/jvm_test.clj
+++ b/test/iapetos/collector/jvm_test.clj
@@ -16,4 +16,7 @@
       (and (registry :iapetos-internal/jvm-standard)
            (registry :iapetos-internal/jvm-gc)
            (registry :iapetos-internal/jvm-memory-pools)
-           (registry :iapetos-internal/jvm-threads)))))
+           (registry :iapetos-internal/jvm-threads)
+           (registry :iapetos-internal/jvm-buffer-pools)
+           (registry :iapetos-internal/jvm-class-loading)
+           (registry :iapetos-internal/jvm-version-info)))))


### PR DESCRIPTION
`io.prometheus/simpleclient` 0.4.0 has new JVM collectors available that aren't present here. This PR makes them available to be registered in the iapetos registry.