### PR TITLE
fix push! to push-gateway

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-commons/iapetos "0.1.9"
+(defproject clj-commons/iapetos "0.1.10"
   :description "A Clojure Prometheus Client"
   :url "https://github.com/clj-commons/iapetos"
   :license {:name "MIT License"
@@ -6,10 +6,10 @@
             :year 2019
             :key "mit"}
   :dependencies [[org.clojure/clojure "1.10.0" :scope "provided"]
-                 [io.prometheus/simpleclient "0.6.0"]
-                 [io.prometheus/simpleclient_common "0.6.0"]
-                 [io.prometheus/simpleclient_pushgateway "0.6.0"]
-                 [io.prometheus/simpleclient_hotspot "0.6.0" :scope "provided"]]
+                 [io.prometheus/simpleclient "0.8.0"]
+                 [io.prometheus/simpleclient_common "0.8.0"]
+                 [io.prometheus/simpleclient_pushgateway "0.8.0"]
+                 [io.prometheus/simpleclient_hotspot "0.8.0" :scope "provided"]]
   :profiles {:dev
              {:dependencies [[org.clojure/test.check "0.9.0"]
                              [aleph "0.4.6"]]


### PR DESCRIPTION
With Iapetos 0.1.9 I was getting an IOException on calling push!, despite push-gateway returning status 200. It's caused by a bug in io.prometheus 0.6.0. Updating Iapetos to use io.prometheus 0.8.0 fixes push!.