### PR TITLE
Add deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,5 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.0"}
+        io.prometheus/simpleclient {:mvn/version "0.8.0"}
+        io.prometheus/simpleclient_common {:mvn/version "0.8.0"}
+        io.prometheus/simpleclient_pushgateway {:mvn/version "0.8.0"}
+        io.prometheus/simpleclient_hotspot {:mvn/version "0.8.0"}}}


### PR DESCRIPTION
Currently, `clojure` users can only pull in released versions by specifying `iapetos` as a `:mvn/version` dependency. This patch add file `deps.edn`, so `clojure` users could specify the dependency as a `:git/url` and `:sha` to pull down and test unreleased versions.