### PR TITLE
Allow labels to be passed to fn instrumentation

### DIFF
--- a/src/iapetos/collector/fn.clj
+++ b/src/iapetos/collector/fn.clj
@@ -28,12 +28,14 @@
    {:keys [duration?
            exceptions?
            last-failure?
-           run-count?]
+           run-count?
+           labels]
     :or {duration? true
          exceptions? true
          last-failure? true
-         run-count? true}}]
-  (let [labels {:fn fn-name, :result "success"}
+         run-count? true
+         labels {}}}]
+  (let [labels (into labels {:fn fn-name, :result "success"})
         failure-labels (assoc labels :result "failure")]
     (wrap->>
       f
@@ -67,24 +69,24 @@
    - `fn_runs_total`: a counter for fn runs, split by success/failure,
    - `fn_exceptions_total`: a counter for fn exceptions, split by class.
    "
-  [registry]
+  [registry & [{:keys [labels]}]]
   (->> (vector
          (prometheus/histogram
            :fn/duration-seconds
            {:description "the time elapsed during execution of the observed function."
-            :labels [:fn]})
+            :labels (into [:fn] labels)})
          (prometheus/gauge
            :fn/last-failure-unixtime
            {:description "the UNIX timestamp of the last time the observed function threw an exception."
-            :labels [:fn]})
+            :labels (into [:fn] labels)})
          (prometheus/counter
            :fn/runs-total
            {:description "the total number of finished runs of the observed function."
-            :labels [:fn :result]})
+            :labels (into [:fn :result] labels)})
          (ex/exception-counter
            :fn/exceptions-total
            {:description "the total number and type of exceptions for the observed function."
-            :labels [:fn]}))
+            :labels (into [:fn] labels)}))
        (reduce prometheus/register registry)))
 
 ;; ## Constructor
@@ -103,7 +105,8 @@
             exceptions?
             duration?
             last-failure?
-            run-count?]
+            run-count?
+            labels]
      :or {fn-name (subs (str fn-var) 2)}
      :as options}]
    (instrument!* registry fn-name fn-var options)))

--- a/test/iapetos/collector/fn_test.clj
+++ b/test/iapetos/collector/fn_test.clj
@@ -10,25 +10,34 @@
 
 ;; ## Generators
 
-(def gen-fn-registry
-  (g/registry-fn fn/initialize))
+(defn gen-fn-registry [label-keys]
+  (g/registry-fn #(fn/initialize %1 {:labels label-keys})))
+
+(def gen-labels
+  (gen/not-empty
+    (gen/map
+    g/metric-string
+    g/metric-string)))
 
 ;; ## Tests
 
 (defspec t-wrap-instrumentation 10
   (prop/for-all
-    [registry-fn gen-fn-registry
+    [[labels registry-fn]
+     (gen/let [labels gen-labels
+               registry-fn (gen-fn-registry (keys labels))]
+       [labels registry-fn])
      [type f]   (gen/elements
                   [[:success #(Thread/sleep 20)]
                    [:failure #(do (Thread/sleep 20) (throw (Exception.)))]])]
     (let [registry (registry-fn)
-          f' (fn/wrap-instrumentation f registry "f" {})
+          f' (fn/wrap-instrumentation f registry "f" {:labels labels})
           start-time (System/currentTimeMillis)
           start (System/nanoTime)
           _  (dotimes [_ 5] (try (f') (catch Throwable _)))
           end-time (System/currentTimeMillis)
           delta (/ (- (System/nanoTime) start) 1e9)
-          val-of #(prometheus/value registry %1 (into {:fn "f"} %2))]
+          val-of #(prometheus/value registry %1 (into {} (list {:fn "f"} labels %2)))]
       (and (<= 0.1 (:sum (val-of :fn/duration-seconds {})) delta)
            (= 5.0 (:count (val-of :fn/duration-seconds {})))
            (or (= type :success)
@@ -51,22 +60,23 @@
 
 (defspec t-instrument! 10
   (prop/for-all
-    [registry-fn gen-fn-registry
-     [type f]    (gen/elements
-                   [[:success #(Thread/sleep 20)]
-                    [:failure #(do (Thread/sleep 20) (throw (Exception.)))]])]
+    [[labels registry-fn]
+     (gen/let [labels gen-labels
+               registry-fn (gen-fn-registry (keys labels))]
+       [labels registry-fn])
+     [type f] (gen/elements
+               [[:success #(Thread/sleep 20)]
+                [:failure #(do (Thread/sleep 20) (throw (Exception.)))]])]
     (reset-test-fn! f)
     (let [registry (doto (registry-fn)
-                     (fn/instrument! #'test-fn))
+                     (fn/instrument! #'test-fn {:labels labels}))
           start-time (System/currentTimeMillis)
           start (System/nanoTime)
+          fn-name "iapetos.collector.fn-test/test-fn"
           _  (dotimes [_ 5] (try (test-fn) (catch Throwable _)))
           end-time (System/currentTimeMillis)
           delta (/ (- (System/nanoTime) start) 1e9)
-          val-of #(prometheus/value
-                    registry
-                    %1
-                    (into {:fn "iapetos.collector.fn-test/test-fn"} %2))]
+          val-of #(prometheus/value registry %1 (into {} (list {:fn fn-name} labels %2)))]
       (and (<= 0.1 (:sum (val-of :fn/duration-seconds {})) delta)
            (= 5.0 (:count (val-of :fn/duration-seconds {})))
            (or (= type :success)


### PR DESCRIPTION
`initialize`, `instrument!`, and `wrap-instrumentation` can now take an optional set of labels.

I'm a little new to clojure, so let me know if there are any style/idiom/etc things I missed!

Addresses https://github.com/clj-commons/iapetos/issues/42


Thanks!