### PR TITLE
Add ::path-cache to registry collectors map metadata

### DIFF
--- a/dev/bench.clj
+++ b/dev/bench.clj
@@ -1,0 +1,81 @@
+(ns bench
+  (:require [clojure.test.check.generators :as gen]
+            [iapetos.core :as prometheus]
+            [iapetos.registry :as r]
+            [iapetos.registry.collectors :as c]
+            [iapetos.test.generators :as g]
+            [jmh.core :as jmh])
+  (:import [iapetos.registry IapetosRegistry]))
+
+(defn metrics
+  [metric-count]
+  (gen/sample g/metric metric-count))
+
+(def dirty-string-metric
+  (gen/let [first-char    gen/char-alpha
+            invalid-chars (gen/return (apply str (map char (range 33 45))))
+            last-char     gen/char-alphanumeric
+            rest-chars    gen/string-alphanumeric]
+    (gen/return
+     (str
+      (apply str first-char invalid-chars rest-chars)
+      last-char))))
+
+(defn dirty-metrics
+  [metric-count]
+  (gen/sample dirty-string-metric metric-count))
+
+;; JMH fns
+
+(defn collectors
+  [^IapetosRegistry registry]
+  (.-collectors registry))
+
+(defn register-collectors
+  [metrics]
+  (reduce (fn [reg metric]
+            (r/register reg metric (prometheus/counter metric)))
+          (r/create)
+          metrics))
+
+(defn lookup
+  [collectors metric]
+  (c/lookup collectors metric {}))
+
+(def bench-env
+  {:benchmarks [{:name :registry-lookup
+                 :fn   `lookup
+                 :args [:state/collectors :state/metric]}
+
+                {:name :dirty-registry-lookup
+                 :fn   `lookup
+                 :args [:state/dirty-collectors :state/dirty-metric]}]
+
+   :states {:dirty-metrics    {:fn `dirty-metrics :args [:param/metric-count]}
+            :dirty-metric     {:fn `rand-nth :args [:state/dirty-metrics]}
+            :dirty-registry   {:fn `register-collectors :args [:state/dirty-metrics]}
+            :dirty-collectors {:fn `collectors :args [:state/dirty-registry]}
+
+            :metrics    {:fn `metrics :args [:param/metric-count]}
+            :metric     {:fn `rand-nth :args [:state/metrics]}
+            :registry   {:fn `register-collectors :args [:state/metrics]}
+            :collectors {:fn `collectors :args [:state/registry]}}
+
+   :params {:metric-count 500}
+
+   :options {:registry-lookup       {:measurement {:iterations 1000}}
+             :dirty-registry-lookup {:measurement {:iterations 1000}}
+             :jmh/default           {:mode             :average
+                                     :output-time-unit :us
+                                     :measurement      {:iterations 1000
+                                                        :count      1}}}})
+
+(def bench-opts
+  {:type   :quick
+   :params {:metric-count 500}})
+
+(comment
+
+  (map #(select-keys % [:fn :mode :name :score]) (jmh/run bench-env bench-opts))
+
+  )

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,9 @@
                  [io.prometheus/simpleclient_hotspot "0.12.0" :scope "provided"]]
   :profiles {:dev
              {:dependencies [[org.clojure/test.check "1.1.0"]
-                             [aleph "0.4.6"]]
+                             [aleph "0.4.6"]
+                             [jmh-clojure "0.4.1"]]
+              :source-paths ["dev"]
               :global-vars {*warn-on-reflection* true}}
              :codox
              {:plugins [[lein-codox "0.10.0"]]

--- a/src/iapetos/collector.clj
+++ b/src/iapetos/collector.clj
@@ -15,6 +15,8 @@
      registries.")
   (metric [this]
     "Return a `iapetos.metric/Metric` for this collector.")
+  (metric-id [this]
+    "Return user supplied (unsanitized) identifier for this collector.")
   (label-instance [this instance values]
     "Add labels to the given collector instance produced by `instantiate`."))
 
@@ -55,6 +57,7 @@
 (defrecord SimpleCollectorImpl [type
                                 namespace
                                 name
+                                metric-id
                                 description
                                 subsystem
                                 labels
@@ -74,6 +77,8 @@
   (metric [_]
     {:name      name
      :namespace namespace})
+  (metric-id [_]
+    metric-id)
   (label-instance [_ instance values]
     (set-labels instance labels values)))
 
@@ -85,7 +90,8 @@
            ^String subsystem
            ^String description
            labels
-           lazy?]}
+           lazy?]
+    ::metric/keys [id]}
    collector-type
    builder-constructor]
   {:pre [type name namespace description]}
@@ -93,6 +99,7 @@
     {:type                collector-type
      :namespace           namespace
      :name                name
+     :metric-id           id
      :description         description
      :subsystem           subsystem
      :labels              (label-names labels)
@@ -119,6 +126,8 @@
     this)
   (metric [this]
     (raw-metric this))
+  (metric-id [this]
+    (hash this))
   (label-instance [_ instance values]
     (if-not (empty? values)
       (throw (UnsupportedOperationException.))
@@ -132,6 +141,8 @@
     (instantiate [_ options]
       (instantiate collector options))
     (metric [_]
+      metric)
+    (metric-id [_]
       metric)
     (label-instance [_ instance values]
       (label-instance collector instance values))))

--- a/src/iapetos/collector/exceptions.clj
+++ b/src/iapetos/collector/exceptions.clj
@@ -43,6 +43,8 @@
     (collector/instantiate counter registry-options))
   (metric [this]
     (collector/metric counter))
+  (metric-id [this]
+    (collector/metric-id counter))
   (label-instance [_ instance values]
     (->ExceptionCounterChild counter instance values)))
 

--- a/src/iapetos/metric.clj
+++ b/src/iapetos/metric.clj
@@ -62,6 +62,7 @@
 
 (defn as-map
   [metric additional-keys]
-  (merge
-    (metric-name metric)
-    additional-keys))
+  (merge (metric-name metric)
+         additional-keys
+         ;; user supplied (unsanitized) identifier e.g., :app/runs-total
+         {::id metric}))

--- a/src/iapetos/registry.clj
+++ b/src/iapetos/registry.clj
@@ -56,7 +56,7 @@
       registry-name
       registry
       (update options :subsystem utils/join-subsystem subsystem-name)
-      {}))
+      (collectors/initialize)))
   (get [_ metric labels]
     (collectors/by collectors metric labels options))
   (raw [_]

--- a/test/iapetos/metric_test.clj
+++ b/test/iapetos/metric_test.clj
@@ -44,4 +44,5 @@
     (let [{:keys [name namespace] :as r} (metric/as-map metric additional-keys)]
       (and (re-matches #"[a-zA-Z0-9_]+" name)
            (re-matches #"[a-zA-Z0-9_]+" namespace)
-           (= additional-keys (dissoc r :name :namespace))))))
+           (= additional-keys (dissoc r :name :namespace ::metric/id))
+           (= metric (::metric/id r))))))

--- a/test/iapetos/registry/collectors_test.clj
+++ b/test/iapetos/registry/collectors_test.clj
@@ -1,0 +1,45 @@
+(ns iapetos.registry.collectors-test
+  (:require [clojure.test.check
+             [generators :as gen]
+             [properties :as prop]
+             [clojure-test :refer [defspec]]]
+            [clojure.test :refer :all]
+            [iapetos.test.generators :as g]
+            [iapetos.core :as prometheus]
+            [iapetos.collector :as collector]
+            [iapetos.registry.collectors :as c])
+  (:import [iapetos.registry IapetosRegistry]))
+
+(defn- all-collectors
+  [^IapetosRegistry registry]
+  (for [[_namespace vs] (.-collectors registry)
+        [_subsystem vs] vs
+        [_name collector] vs]
+    collector))
+
+(defn- path-cache
+  [^IapetosRegistry registry]
+  (::c/path-cache (meta (.-collectors registry))))
+
+(defspec t-registry-should-cache-the-path-of-registered-collectors 50
+  (prop/for-all
+   [registry              (gen/return (prometheus/collector-registry))
+    collector-constructor g/collector-constructor
+    collector-name        g/metric]
+   (let [collector  (collector-constructor collector-name)
+         registry   (prometheus/register registry collector)
+         cache      (path-cache registry)]
+     (is (every? (fn [{:keys [path cache-key] :as _collector}]
+                   (= path (get cache cache-key)))
+                 (all-collectors registry))))))
+
+(defspec t-registry-should-evict-path-from-cache-for-unregistered-collectors 50
+  (prop/for-all
+   [registry              (gen/return (prometheus/collector-registry))
+    collector-constructor g/collector-constructor
+    collector-name        g/metric]
+   (let [collector  (collector-constructor collector-name)
+         registry   (-> registry
+                        (prometheus/register collector)
+                        (prometheus/unregister collector))]
+     (is (empty? (path-cache registry))))))


### PR DESCRIPTION
An update to the [Java Client Library](https://github.com/prometheus/client_java/pull/777) was merged that improved performance of metric name sanitization. Unfortunately it also includes the [move to OpenMetrics](https://github.com/prometheus/client_java/pull/615) that would cause many issues at Nubank. We would like to get the benefit of the metric sanitization performance improvement but cannot upgrade the client at this time.

We shifted our focus to Iapetos in an attempt to implement the improvement here. During the investigation we noticed that collector lookup from the registry sanitizes the metric names on every invocation. In order to limit, as much as possible, the redundant sanitization, we added a _simple_ cache holding the paths to the collectors.

If the cache does not result in a hit, perhaps because the collector was registered with a `keyword` and then referenced by another supported type such as a `vector`, the implementation falls back to computing the path again.

For example:

```clojure
(defonce registry
  (-> (prometheus/collector-registry)
      (prometheus/register
       (prometheus/counter :app/runs-!!!total))))

(.get registry [:app :runs-!!!total] {}) ;; cache MISS, path computed
(.get registry :app/runs-total {}) ;; cache MISS, path computed
(.get registry :app/runs-!!!total {}) ;; cache HIT
```

Included in the PR is a benchmark of the results:

On the `master` branch we see:

```
 {:fn bench/lookup,
  :mode :average,
  :name :registry-lookup,                          ;; metric names do not need to be sanitized
  :score [1.014698602638397 "us/op"]}

 {:fn bench/lookup,
  :mode :average,
  :name :dirty-registry-lookup,                    ;; metric names NEED to be sanitized
  :score [1.9870187159904702 "us/op"]}
```

With the addition of a cache we observed the following performance improvement:

```
 {:fn bench/lookup,
  :mode :average,
  :name :registry-lookup,                          ;; metric names do not need to be sanitized
  :score [0.18071412341478607 "us/op"]}

 {:fn bench/lookup,
  :mode :average,
  :name :dirty-registry-lookup,                    ;; metric names NEED to be sanitized
  :score [0.1301492753507884 "us/op"]}
```
